### PR TITLE
Updating to latest natsclient. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ env_logger = "0.7.1"
 crossbeam-channel = "0.4.2"
 crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
-natsclient = "0.0.6"
+natsclient = "0.0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nats-provider"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
natsclient 0.0.6 points to nkeys version 0.0.8 which has issue https://github.com/encabulators/nkeys/issues/2.

natsclient 0.0.7 points to nkeys version 0.0.9 which has fixed this issue. 

Updating nats-provider to use natsclient 0.0.7. 